### PR TITLE
Fix duplicate default export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,3 @@ export { CloudflareWorker } from './cloudflare-worker';
 export { MCPDurableObject } from './mcp-durable';
 export { MyMCP as MemoryAgent } from './mcp'; // Export MyMCP as MemoryAgent for clarity
 export default app;
-export default app;


### PR DESCRIPTION
## Summary
- remove duplicate default export in `src/index.ts`

## Testing
- `npm run lint:fix` *(fails: biome not installed)*
- `npm run type-check` *(fails: tsc not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d2a8f5e48832e95767bd243ba608b